### PR TITLE
Expand interfaces to allow forking contexts

### DIFF
--- a/include/decaf.h
+++ b/include/decaf.h
@@ -21,11 +21,21 @@ namespace decaf {
   class Context {
   public:
     std::vector<StackFrame> stack;
+    z3::solver solver;
 
     Context fork() const {
       assert("not implemented");
       std::exit(EXIT_FAILURE);
     }
+  };
+
+  class Executor {
+  private:
+    std::vector<Context> contexts;
+
+  public:
+    void add_context(Context&& ctx) {}
+    void add_failure(const z3::model& model) {}
   };
 
   enum class ExecutionResult {
@@ -37,6 +47,7 @@ namespace decaf {
   class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
   private:
     Context* ctx; // Non-owning context reference
+    Executor* exec;
 
   public:
     // Add some more parameters here

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -1,2 +1,4 @@
 
 #include "decaf.h"
+
+#include <llvm/IR/Instructions.h>


### PR DESCRIPTION
This PR adds the following API methods
- `add_context` - add a context to the queue
- `add_failure` - record a context failure