### PR TITLE
Add assert macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(decaf)
 
-# C++17 has a bunch of nice stuff, seems like a good level to target.
-set(CXX_STANDARD_REQUIRED 17)
-
 find_package(LLVM 10.0 REQUIRED)
 find_package(GTest REQUIRED)
 find_package(Z3 REQUIRED)
@@ -12,6 +9,27 @@ find_package(Z3 REQUIRED)
 enable_testing()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
+# C++17 has a bunch of nice stuff, seems like a good level to target.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+# Compiler-specific warning options
+# Add more here as we find ones we want enabled.
+if (MSVC)
+  # This disables all warnings in headers included with angle brackets
+  #
+  # Since these should always be external dependencies in which we don't
+  # care about warnings anyway this is a good thing
+  add_compile_options(
+    /experimental:external
+    /external:anglebrackets
+    /external:W0
+  )
+
+  # Enable more detailed warnings (but not all of them).
+  add_compile_options(/W4)
+endif()
 
 file(
   GLOB_RECURSE sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Z3 REQUIRED)
 
 enable_testing()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 file(
   GLOB_RECURSE sources
   src/*.cpp

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <unordered_map>
 
+#include "macros.h"
+
 namespace decaf {
   class StackFrame {
   public:
@@ -30,8 +32,7 @@ namespace decaf {
 
   enum class ExecutionResult {
     Continue,
-    Stop,
-    Unimplemented
+    Stop
   };
 
   class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
@@ -43,22 +44,21 @@ namespace decaf {
     Interpreter();
 
     ExecutionResult visitInstruction(llvm::Instruction& I) {
-      assert("Instruction not implemented");
-      return ExecutionResult::Unimplemented;
+      DECAF_UNIMPLEMENTED();
     }
 
     // Replace this with implementation in cpp file as we go
-    ExecutionResult visitAdd(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitSub(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitMul(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitUDiv(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitSDiv(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitURem(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitSRem(llvm::BinaryOperator& op) { return ExecutionResult::Unimplemented; }
+    ExecutionResult visitAdd(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitSub(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitMul(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitUDiv(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitSDiv(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitURem(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitSRem(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
 
-    ExecutionResult visitPHINode(llvm::PHINode& node) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitBranchInst(llvm::BranchInst& inst) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitReturnInst(llvm::ReturnInst& inst) { return ExecutionResult::Unimplemented; }
-    ExecutionResult visitCallInst(llvm::CallInst& inst) { return ExecutionResult::Unimplemented; }
+    ExecutionResult visitPHINode(llvm::PHINode& node) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitBranchInst(llvm::BranchInst& inst) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitReturnInst(llvm::ReturnInst& inst) { DECAF_UNIMPLEMENTED(); }
+    ExecutionResult visitCallInst(llvm::CallInst& inst) { DECAF_UNIMPLEMENTED(); }
   };
 }

--- a/include/macros.h
+++ b/include/macros.h
@@ -1,0 +1,106 @@
+
+#ifndef DECAF_MACROS_H
+#define DECAF_MACROS_H
+
+#include <string_view>
+
+namespace decaf {
+  namespace detail {
+    /** Optional-like type for use in message creation.
+     * 
+     * I'm trying to keep this header lightweight so that including it
+     * everywhere is less of an issue.
+     * 
+     * This struct should not usually be used directly. Use one of the
+     * assertion or abortion macros instead.
+     */
+    struct message {
+      bool has_value;
+      std::string_view msg;
+
+      message() : has_value(false) {}
+      message(std::string_view msg) : has_value(true), msg(msg) {}
+    };
+
+    /**
+     * Exit the process with an "assertion failed" message and print a
+     * backtrace of where the assertion failed.
+     * 
+     * Usually, this function should not be called directly. Use
+     * DECAF_ASSERT instead.
+     */
+    [[noreturn]] void assert_fail(
+      const char* condition,
+      const char* function,
+      unsigned int line,
+      const char* file,
+      message message
+    );
+
+    /**
+     * Exit the process with an abort message and print a backtrace of
+     * where the process aborted.
+     * 
+     * Usually, this function should not be called directly. Use DECAF_ABORT
+     * or one of the other abortion macros such as DECAF_UNIMPLEMENTED or
+     * DECAF_UNREACHABLE instead.
+     */
+    [[noreturn]] void abort(
+      const char* function,
+      unsigned int line,
+      const char* file,
+      message message
+    );
+  }
+}
+
+#ifdef __PRETTY_FUNCTION__
+#  define DECAF_FUNCTION __PRETTY_FUNCTION__
+#else
+#  define DECAF_FUNCTION __FUNCTION__
+#endif
+
+/**
+ * Abort the process if the condition is not true.
+ * 
+ * There are two valid forms for this assert macro
+ * ```
+ * DECAF_ASSERT(cond);
+ * DECAF_ASSERT(cond, "some message");
+ * ```
+ * 
+ * The only difference is that the first one uses a default message and the
+ * second one uses the provided message when it fails.
+ * 
+ * Note that the message is only evaluated if the assertion fails.
+ */
+#define DECAF_ASSERT(cond, ...)               \
+  do {                                        \
+    if (!(cond)) {                            \
+      ::decaf::detail::assert_fail(           \
+        #cond,                                \
+        DECAF_FUNCTION,                       \
+        __LINE__,                             \
+        __FILE__,                             \
+        ::decaf::detail::message(__VA_ARGS__) \
+      );                                      \
+    }                                         \
+  } while (false)
+
+/**
+ * Abort the process with an optional message.
+ */
+#define DECAF_ABORT(...)                  \
+  ::decaf::detail::abort(                 \
+    DECAF_FUNCTION,                       \
+    __LINE__,                             \
+    __FILE__,                             \
+    ::decaf::detail::message(__VA_ARGS__) \
+  )
+
+// Abort the process with a message about unreachable code
+#define DECAF_UNREACHABLE() DECAF_ABORT("entered unreachable code")
+// Abort the process with a "not implemented" message.
+#define DECAF_UNIMPLEMENTED() DECAF_ABORT("not implemented")
+
+#endif

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -1,0 +1,62 @@
+
+#include "macros.h"
+
+#include <boost/core/demangle.hpp>
+#include <boost/stacktrace.hpp>
+
+#include <sstream>
+#include <iostream>
+
+namespace decaf::detail {
+  [[noreturn]] void assert_fail(
+    const char* condition,
+    const char* function,
+    unsigned int line,
+    const char* file,
+    message message
+  ) {
+    auto stacktrace = boost::stacktrace::stacktrace();
+    auto demangled = boost::core::demangle(function);
+
+    std::cerr
+      << "Assertion failed: " << condition << "\n"
+      << "  location: " << file << ":" << line << "\n"
+      << "  function: " << demangled << "\n";
+
+    if (message.has_value) {
+      std::cerr << "  message: " << message.msg << "\n";
+    }
+
+    std::cerr
+      << "\n"
+      << stacktrace << "\n";
+
+    std::exit(255);
+  }
+
+  [[noreturn]] void abort(
+    const char* function,
+    unsigned int line,
+    const char* file,
+    message message
+  ) {
+    auto stacktrace = boost::stacktrace::stacktrace();
+    auto demangled = boost::core::demangle(function);
+
+    if (message.has_value) {
+      std::cerr
+        << "Aborted with message: " << message.msg << "\n"
+        << "  location: " << file << ":" << line << "\n";
+    } else {
+      std::cerr << "Aborted at " << file << ":" << line << "\n"; 
+    }
+
+    std::cerr
+      << "  function: " << demangled << "\n"
+      << "  Stack Trace:\n"
+      << stacktrace
+      << "\n";
+
+    std::exit(255);
+  }
+}


### PR DESCRIPTION
This adds a number of assert and abort macros. On failure all of them will do the following
- Print file, line, and function where they were triggered
- (For assertions) print the condition that failed
- (If properly configured) print the stack trace at which the error occurred

It also changes the unimplemented method on the `Interpreter` class to use the new `DECAF_UNIMPLEMENTED()` macro instead.

I've also pushed in some cmake changes to make everything work well under MSVC.