### PR TITLE
Tweak CMakeLists.txt languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(decaf)
+project(decaf LANGUAGES C CXX)
 
 find_package(LLVM 10.0 REQUIRED)
 find_package(GTest REQUIRED)


### PR DESCRIPTION
This commit adds the C and CXX langs to the CMakeLists.txt file.
Without it, there's a potential to run into issues when cmake
is generating makefiles (CMAKE_C_COMPILER not set)