### PR TITLE
Implement main loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ if (MSVC)
 
   # Enable more detailed warnings (but not all of them).
   add_compile_options(/W4)
+
+  # Some code within LLVM triggers this. It's not something we can fix so
+  # better to silence the warning than have it drown everything out.
+  add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS=1)
 endif()
 
 file(

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -39,11 +39,17 @@ namespace decaf {
   public:
     // The current context has forked and the fork needs to be added
     // to the queue.
-    void add_context(Context&& ctx) {}
+    void add_context(Context&& ctx);
 
     // The current context has encountered a failure that needs to be
     // recorded.
-    void add_failure(const z3::model& model) {}
+    void add_failure(const z3::model& model);
+
+    // Get the next context to be executed.
+    Context next_context();
+
+    // Are there any contexts left?
+    bool has_next() const;
   };
 
   enum class ExecutionResult {

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -2,8 +2,36 @@
 #include "decaf.h"
 
 #include <llvm/IR/Instructions.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <iostream>
 
 namespace decaf {
+  void Executor::add_context(Context&& ctx) {
+    contexts.push_back(ctx);
+  }
+
+  void Executor::add_failure(const z3::model& model) {
+    // TODO: It might not be necessary for the prototype but we'll need
+    //       to figure what we want to do with test failures.
+    std::cout
+      << "Found failed model! Inputs: \n"
+      << model << std::endl;
+  }
+
+  Context Executor::next_context() {
+    DECAF_ASSERT(has_next());
+
+    Context ctx = std::move(contexts.back());
+    contexts.pop_back();
+    return ctx;
+  }
+
+  bool Executor::has_next() const {
+    return !contexts.empty();
+  }
+
+
   void Interpreter::execute() {
     ExecutionResult exec;
 

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -5,8 +5,12 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <iostream>
+#include <stdexcept>
 
 namespace decaf {
+  /************************************************
+   * Executor                                     *
+   ************************************************/
   void Executor::add_context(Context&& ctx) {
     contexts.push_back(ctx);
   }
@@ -31,6 +35,42 @@ namespace decaf {
     return !contexts.empty();
   }
 
+  /************************************************
+   * StackFrame                                   *
+   ************************************************/
+  StackFrame::StackFrame(llvm::Function* function) :
+    function(function),
+    current_block(&function->getEntryBlock()),
+    prev_block(nullptr),
+    current(current_block->begin())
+  {}
+
+  /************************************************
+   * Context                                      *
+   ************************************************/
+  Context::Context(z3::context& z3, llvm::Function* function) :
+    solver(z3)
+  {
+    stack.emplace_back(function);
+    StackFrame& frame = stack_top();
+
+    int argnum = 0;
+    for (auto& arg : function->args()) {
+      z3::sort sort = sort_for_type(z3, arg.getType());
+      z3::symbol symbol = z3.int_symbol(argnum);
+
+      frame.variables.insert({ &arg, z3.constant(symbol, sort) });
+      argnum += 1;
+    }
+  }
+
+
+  /************************************************
+   * Interpreter                                  *
+   ************************************************/
+  Interpreter::Interpreter(Context* ctx, Executor* queue, z3::context* z3) :
+    ctx(ctx), queue(queue), z3(z3)
+  {}
 
   void Interpreter::execute() {
     ExecutionResult exec;
@@ -51,5 +91,42 @@ namespace decaf {
 
       exec = visit(inst);
     } while (exec == ExecutionResult::Continue);
+  }
+
+  /************************************************
+   * Free Functions                               *
+   ************************************************/
+  z3::sort sort_for_type(z3::context& ctx, llvm::Type* type) {
+    if (type->isIntegerTy()) {
+      return ctx.bv_sort(type->getIntegerBitWidth());
+    }
+
+    std::string message;
+    llvm::raw_string_ostream os{message};
+    os << "Unsupported LLVM type: ";
+    type->print(os);
+
+    DECAF_ABORT(message);
+  }
+
+  void execute_symbolic(llvm::Function* function) {
+    z3::config cfg;
+
+    // We want Z3 to generate models
+    cfg.set("model", true);
+    // Automatically select and configure the solver
+    cfg.set("auto_config", true);
+
+    z3::context z3{cfg};
+    Executor exec;
+
+    exec.add_context(Context(z3, function));
+
+    while (exec.has_next()) {
+      Context ctx = exec.next_context();
+      Interpreter interp{&ctx, &exec, &z3};
+
+      interp.execute();
+    }
   }
 }


### PR DESCRIPTION
This PR implements the main loop along with several small utility methods.

Currently I've made it so that when we record a failure it just prints out the failure to stdout. Obviously this won't work for a proper implementation but I think it works well enough for a proof of concept. Currently it works by making all function arguments (for the initial function) symbolic. There isn't really another way to do that until we add support for memory so I think this should be good enough for now.

With this in place I can write an actual main method that takes in a llvm bitcode file and then executes (or, well, tries too right now) it symbolically.

Closes #6 