### PR TITLE
Add CircleCI configuration and Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: insufficientlycaffeinated/bob:latest
+    steps:
+      - checkout
+      - run: mkdir build && cd build && cmake .. && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
   build:
     docker:
       - image: insufficientlycaffeinated/bob:latest
+        auth:
+            username: $DOCKERHUB_USER
+            password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run: mkdir build && cd build && cmake .. && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,4 @@ jobs:
     steps:
       - checkout
       - run: mkdir build && cd build && cmake .. && make
+      - run: ctest . --output-on-failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:latest
+# This Dockerfile creates https://hub.docker.com/r/insufficientlycaffeinated/bob
+# Currently there's no automatic build set up for this, so changes to this file
+# should be followed by rebuilding the container and pushing it to dockerhub.
+# Luckily that won't happen very often (because changes can be made in Circle
+# faster)
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt -y install \
+    llvm-dev \
+    libz-dev \
+    build-essential \
+    gcc \
+    g++ \
+    git \
+    make \
+    cmake \
+    libgtest-dev \
+    python3-distutils \
+    libfmt-dev \
+    libboost-all-dev
+RUN git clone https://github.com/Z3Prover/z3.git
+RUN mkdir z3/build && cd z3/build && cmake .. && make && make install
+RUN rm -rf z3

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ FROM ubuntu:latest
 # faster)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt -y install \
-    llvm-dev \
+    llvm-10-dev \
     libz-dev \
     build-essential \
-    gcc \
-    g++ \
+    gcc-9 \
+    g++-9 \
     git \
     make \
     cmake \


### PR DESCRIPTION
This PR adds a Dockerfile with a recipe for an ubuntu image that
has our dependencies installed. It also adds the initial Circle
config.

Addresses #3 