### PR TITLE
Add context and cd into build for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 workflows:
-  my-workflow:
+  default-workflow:
     jobs:
       - build:
           # for https://circleci.com/docs/2.0/private-images/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,22 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+workflows:
+  my-workflow:
+    jobs:
+      - build:
+          # for https://circleci.com/docs/2.0/private-images/
+          context:
+            - docker-hub-creds
+
 jobs:
   build:
     docker:
       - image: insufficientlycaffeinated/bob:latest
         auth:
+            # currently unused, but will be easy to set up if dockerhub starts blocking us
             username: $DOCKERHUB_USER
             password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run: mkdir build && cd build && cmake .. && make
-      - run: ctest . --output-on-failure
+      - run: cd build && ctest . --output-on-failure


### PR DESCRIPTION
The tests were being executed in the wrong directory. This PR
also sets up a context for docker hub credentials. This is useful
in case we get hit by a rate limit (docker hub will be implementing
those soon apparently)