### PR TITLE
Optimize dockerfile image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,30 @@ FROM ubuntu:latest
 # Luckily that won't happen very often (because changes can be made in Circle
 # faster)
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt -y install \
-    llvm-10-dev \
-    libz-dev \
-    build-essential \
-    gcc-9 \
-    g++-9 \
-    git \
-    make \
-    cmake \
-    libgtest-dev \
-    python3-distutils \
-    libfmt-dev \
-    libboost-all-dev
-RUN git clone https://github.com/Z3Prover/z3.git
-RUN mkdir z3/build && cd z3/build && cmake .. && make && make install
-RUN rm -rf z3
+
+
+RUN apt update \
+    && apt -y install \
+        llvm-10-dev \
+        libz-dev \
+        build-essential \
+        gcc-9 \
+        g++-9 \
+        git \
+        make \
+        cmake \
+        libgtest-dev \
+        python3-distutils \
+        libfmt-dev \
+        libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# This is all done in 1 run command so that we don't end up storing the
+# intermediate layers in the final dockerfile
+RUN git clone https://github.com/Z3Prover/z3.git && \
+    mkdir -p z3/build && \
+    cd z3/build && \
+    cmake .. && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf z3


### PR DESCRIPTION
This PR combines commands within the dockerfile to avoid storing large intermediate layers. It also clears out the apt cache after downloading the packages.

I haven't measured the size improvement yet but I expect it should be pretty good.