### PR TITLE
Implement decaf executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,5 +64,6 @@ target_link_libraries(decaf-tests PRIVATE decaf)
 target_link_libraries(decaf-tests PRIVATE GTest::GTest)
 add_test(NAME decaf-tests COMMAND decaf-tests)
 
-target_link_libraries(decaf-bin PRIVATE decaf)
 set_target_properties(decaf-bin PROPERTIES OUTPUT_NAME decaf)
+target_link_libraries(decaf-bin PRIVATE decaf)
+target_link_libraries(decaf-bin PRIVATE LLVMIRReader)

--- a/main.cpp
+++ b/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
 
   auto function = module->getFunction(target_method.getValue());
   if (!function) {
-        errs() << argv[0] << ": ";
+    errs() << argv[0] << ": ";
     WithColor::error() << " no method '" << target_method.getValue() << "'";
     return 1;
   }

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,93 @@
 
+#include "decaf.h"
+
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/WithColor.h>
+
 #include <iostream>
+#include <memory>
+
+using namespace llvm;
+
+cl::opt<std::string> input_filename{cl::Positional};
+cl::opt<std::string> target_method{cl::Positional};
+
+static ExitOnError exit_on_err;
+
+namespace {
+  struct DecafDiagnosticHandler : public DiagnosticHandler {
+    bool handleDiagnostics(const DiagnosticInfo& di) override {
+      unsigned severity = di.getSeverity();
+      switch (severity) {
+      case DS_Error:
+        WithColor::error();
+        break;
+      case DS_Warning:
+        WithColor::warning();
+        break;
+      case DS_Remark:
+        WithColor::remark();
+        break;
+      case DS_Note:
+        WithColor::note();
+        break;
+      default:
+        llvm_unreachable("DiagnosticInfo had unknown severity level");
+      }
+
+      DiagnosticPrinterRawOStream dp(errs());
+      di.print(dp);
+      errs() << '\n';
+
+      return true;
+    }
+  };
+}
+
+static std::unique_ptr<Module>
+loadFile(const char* argv0, const std::string& filename, LLVMContext& context) {
+  llvm::SMDiagnostic error;
+  auto module = llvm::parseIRFile(filename, error, context);
+
+  if (!module) {
+    error.print(argv0, llvm::errs());
+    return nullptr;
+  }
+
+  return module;
+}
 
 int main(int argc, char** argv) {
-  std::cout << "Hello, World!" << std::endl;
+  InitLLVM X(argc, argv);
+  exit_on_err.setBanner(std::string(argv[0]) + ":");
+
+  LLVMContext context;
+  context.setDiagnosticHandler(
+    std::make_unique<DecafDiagnosticHandler>(), true);
+
+  cl::ParseCommandLineOptions(argc, argv, "symbolic executor for LLVM IR");
+
+  auto module = loadFile(argv[0], input_filename.getValue(), context);
+  if (!module) {
+    errs() << argv[0] << ": ";
+    WithColor::error() << " loading file '" << input_filename.getValue()
+                       << "'\n";
+    return 1;
+  }
+
+  auto function = module->getFunction(target_method.getValue());
+  if (!function) {
+        errs() << argv[0] << ": ";
+    WithColor::error() << " no method '" << target_method.getValue() << "'";
+    return 1;
+  }
+
+  decaf::execute_symbolic(function);
+  
   return 0;
 }


### PR DESCRIPTION
This changes decaf-bin to be an executable which takes a llvm bitcode file along with a method within that bitcode file and then that method symbolically.

This means that the executable should be run like this
```
decaf <bitcode.bc> <test-method>
```

At this point I haven't included any documentation as to this within the executable itself. I expect that we'll change the command line interface in the future (although maybe not as part of the prototype) once the number of applications that we are able to run increases.

Note that this PR won't compile until #17 lands since that PR adds an implementation of `StackFrame::stack_top` which is needed for linking to complete.

Closes #12.