### PR TITLE
Properly normalize expressions within add opcode

### DIFF
--- a/include/decaf.h
+++ b/include/decaf.h
@@ -193,8 +193,19 @@ namespace decaf {
    * Justification
    * =============
    * LLVM represents booleans using 1-bit integers and most of the time
-   * they're being used as booleans so it's easier to normalize them to
-   * booleans when needed.
+   * they're being used as booleans so we need some conversion methods
+   * for when we have one and need the other.
    */
   z3::expr normalize_to_bool(const z3::expr& expr);
+  /**
+   * Normalize a Z3 expression to represent booleans as integers.
+   * Doesn't affect any other expression type.
+   * 
+   * Justification
+   * =============
+   * LLVM represents booleans using 1-bit integers and most of the time
+   * they're being used as booleans so we need some conversion methods
+   * for when we have one and need the other.
+   */
+  z3::expr normalize_to_int(const z3::expr& expr);
 }

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -165,8 +165,8 @@ namespace decaf {
   ExecutionResult Interpreter::visitAdd(llvm::BinaryOperator& op) {
     StackFrame& frame = ctx->stack_top();
 
-    auto lhs = frame.lookup(op.getOperand(0), *z3);
-    auto rhs = frame.lookup(op.getOperand(1), *z3);
+    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
 
     frame.insert(&op, lhs + rhs);
 
@@ -282,6 +282,17 @@ namespace decaf {
 
     if (sort.is_int() && sort.bv_size() == 1)
       return expr == 1;
+
+    return expr;
+  }
+
+  z3::expr normalize_to_int(const z3::expr& expr) {
+    auto sort = expr.get_sort();
+
+    if (sort.is_bool()) {
+      auto& ctx = expr.ctx();
+      return z3::ite(expr, ctx.bv_val(1, 1), ctx.bv_val(0, 1));
+    }
 
     return expr;
   }

--- a/tests/opcodes.cpp
+++ b/tests/opcodes.cpp
@@ -134,7 +134,7 @@ TEST(opcodes, 1bit_add_test) {
   auto expr1 = frame.lookup(add1, z3);
 
   // 1 + 0 == 1 (mod 2)
-  EXPECT_EQ(ctx.check(expr0 == true), z3::sat);
+  EXPECT_EQ(ctx.check(expr0 == 1), z3::sat);
   // 1 + 1 == 0 (mod 2)
-  EXPECT_EQ(ctx.check(expr1 == false), z3::sat);
+  EXPECT_EQ(ctx.check(expr1 == 0), z3::sat);
 }


### PR DESCRIPTION
This PR changes the add implementation to properly work in the case where a boolean is masquerading as an integer. 

For a bit more detail, this can happen in the case where a program is doing arithmetic on booleans. There's a bit of a mismatch between LLVM and Z3 in that Z3 has distinct boolean and 1-bit integer types whereas LLVM only has the integer types. The representations that's the quickest is to use booleans as we'll spend most of the time doing boolean-y things with them but it's still necessary to support integer operations on them. The easiest way to make this work is just to lazily convert them when needed.

I've also added a test case covering this specific scenario. We should probably add similar tests when we implement other operations.