### PR TITLE
Remove docker from circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       - checkout
       - run:
           command: |
-            DEBIAN_FRONTEND=noninteractive
             apt update
             apt -y install \
               llvm-10-dev \
@@ -21,5 +20,7 @@ jobs:
               python3-distutils \
               libfmt-dev \
               libboost-all-dev
+          environment:
+            DEBIAN_FRONTEND: noninteractive
       - run: mkdir build && cd build && cmake .. && make
       - run: cd build && ctest . --output-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 jobs:
   build:
-      docker:
-        - image: ubuntu:latest
-  build:
+    docker:
+      - image: ubuntu:latest
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 jobs:
   build:
+      docker:
+        - image: ubuntu:latest
+  build:
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ jobs:
       - checkout
       - run:
           command: |
-            apt update && apt -y install \
+            DEBIAN_FRONTEND=noninteractive
+            apt update
+            apt -y install \
               llvm-10-dev \
               libz-dev \
               build-essential \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ jobs:
       - checkout
       - run:
           command: |
-            apt update
-            && apt -y install \
+            apt update && apt -y install \
               llvm-10-dev \
               libz-dev \
               build-essential \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,22 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
-version: 2.1
-workflows:
-  default-workflow:
-    jobs:
-      - build:
-          # for https://circleci.com/docs/2.0/private-images/
-          context:
-            - docker-hub-creds
-
 jobs:
   build:
-    docker:
-      - image: insufficientlycaffeinated/bob:latest
-        auth:
-            # currently unused, but will be easy to set up if dockerhub starts blocking us
-            username: $DOCKERHUB_USER
-            password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
+      - run:
+          command: |
+            apt update
+            && apt -y install \
+              llvm-10-dev \
+              libz-dev \
+              build-essential \
+              gcc-9 \
+              g++-9 \
+              git \
+              make \
+              cmake \
+              libgtest-dev \
+              python3-distutils \
+              libfmt-dev \
+              libboost-all-dev
       - run: mkdir build && cd build && cmake .. && make
       - run: cd build && ctest . --output-on-failure


### PR DESCRIPTION
This removes the docker dependency from circleci since the whole project can use the prebuilt system packages on Ubuntu