### PR TITLE
Change .clang-format to only specify needed options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,7 @@
-{
-  AccessModifierOffset: -2,
-  AllowShortBlocksOnASingleLine: true,
-  AllowShortFunctionsOnASingleLine: Empty,
-  AllowShortIfStatementsOnASingleLine: false,
-  BasedOnStyle: LLVM,
-  BreakBeforeBraces: Attach,
-  ColumnLimit: 100,
-  IndentCaseLabels: false,
-  IndentWidth: 2,
-  TabWidth: 2
-}
+---
+BasedOnStyle: LLVM
+
+AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 100
+NamespaceIndentation: Inner

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,13 @@
+name: test-clang-format
+
+on: pull_request
+
+jobs:
+  build:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: DoozyX/clang-format-lint-action@v0.10
+          with:
+            source: '.'
+            clangFormatVersion: 9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ file(
   tests/*.hpp
 )
 
+set(fmt_sources "${sources}" "${tests}")
+
 add_library(decaf STATIC ${sources})
 add_executable(decaf-tests ${tests})
 add_executable(decaf-bin main.cpp)
@@ -76,3 +78,9 @@ add_test(NAME decaf-tests COMMAND decaf-tests)
 set_target_properties(decaf-bin PROPERTIES OUTPUT_NAME decaf)
 target_link_libraries(decaf-bin PRIVATE decaf)
 target_link_libraries(decaf-bin PRIVATE LLVMIRReader)
+
+add_custom_target(format
+  COMMAND clang-format -i ${fmt_sources}
+  VERBATIM
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,16 @@ if (MSVC)
   # Some code within LLVM triggers this. It's not something we can fix so
   # better to silence the warning than have it drown everything out.
   add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS=1)
+elseif(UNIX)
+  if (CMAKE_GENERATOR STREQUAL "Ninja")
+    # By default error messages are emitted without colour when compiling
+    # with Ninja. This turns on coloured diagnostics by default.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      add_compile_options(-fdiagnostics-color=always)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      add_compile_options(fcolor-diagnostics)
+    endif()
+  endif()
 endif()
 
 file(

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -4,216 +4,219 @@
 #include <z3++.h>
 
 #include <cassert>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "macros.h"
 
 namespace decaf {
-  class StackFrame {
-  public:
-    std::unordered_map<llvm::Value*, z3::expr> variables;
-    
-    llvm::Function* function;
-    llvm::BasicBlock* current_block;
-    llvm::BasicBlock* prev_block;
-    llvm::BasicBlock::iterator current;
+class StackFrame {
+public:
+  std::unordered_map<llvm::Value *, z3::expr> variables;
 
-    StackFrame(llvm::Function* function);
-    
-    /**
-     * Insert a new value into the current stack frame. If that value
-     * is already in the current stack frame then it overwrites it.
-     */
-    void insert(llvm::Value* value, const z3::expr& expr);
-    /**
-     * Lookup a value within the current stack frame.
-     * 
-     * There are two main cases here:
-     * 1. `value` is an existing variable
-     * 2. `value` is a constant
-     * 
-     * In the first case we just look up the variable the `variables` map
-     * and then return it. In the second case we build a Z3 expression
-     * that represents the constant and return that.
-     * 
-     * This method should be preferred over directly interacting with
-     * `variables` as it correctly handles constants.
-     */
-    z3::expr lookup(llvm::Value* value, z3::context& ctx) const;
-  };
+  llvm::Function *function;
+  llvm::BasicBlock *current_block;
+  llvm::BasicBlock *prev_block;
+  llvm::BasicBlock::iterator current;
 
-  class Context {
-  public:
-    std::vector<StackFrame> stack;
-    z3::solver solver;
-
-  private:
-    Context(const Context& ctx, z3::solver&& solver);
-
-  public:
-    Context(z3::context& z3, llvm::Function* function);
-
-    /**
-     * Create a new context that is independant from this
-     * one but has the same state.
-     */
-    Context fork() const;
-
-    /**
-     * Get the top frame of the stack.
-     * 
-     * This should be used instead of directly manipulating the stack
-     * vector so that it continues to work when more advanced data
-     * structures are implemented. 
-     */
-    StackFrame& stack_top();
-
-    /**
-     * Check whether the current set of assertions + the given expression
-     * is satisfiable.
-     * 
-     * Does not modify the solver state. If this returns sat then you can
-     * get the solver model as a test case.
-     * 
-     * This will cause an assertion failure if expr is not either a boolean
-     * or a 1-bit integer. 1-bit integers will be implicitly converted to
-     * a boolean.
-     */
-    z3::check_result check(const z3::expr& expr);
-    /**
-     * Check whether the current set of assertions is satisifiable.
-     * 
-     * If this returns sat then you can extract a model by calling
-     * `solver.model()`.
-     */
-    z3::check_result check();
-
-    /**
-     * Add a new assertion to the solver.
-     */
-    void add(const z3::expr& assertion);
-  };
-
-  class Executor {
-  private:
-    std::vector<Context> contexts;
-
-  public:
-    // The current context has forked and the fork needs to be added
-    // to the queue.
-    void add_context(Context&& ctx);
-
-    // The current context has encountered a failure that needs to be
-    // recorded.
-    void add_failure(const z3::model& model);
-
-    // Get the next context to be executed.
-    Context next_context();
-
-    // Are there any contexts left?
-    bool has_next() const;
-  };
-
-  enum class ExecutionResult {
-    Continue,
-    Stop
-  };
-
-  class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
-  private:
-    Context* ctx;
-    Executor* queue;
-    z3::context* z3;
-
-  public:
-    // Add some more parameters here
-    Interpreter(Context* ctx, Executor* queue, z3::context* z3);
-
-    /**
-     * Execute this interpreter's context until it finishes.
-     * 
-     * Contexts from forks will be placed into the execution queue.
-     * Failures resulting from this context will also be added to
-     * the execution queue.
-     */
-    void execute();
-
-    // Marks an unimplemented instruction.
-    //
-    // TODO: Better error message?
-    ExecutionResult visitInstruction(llvm::Instruction&) {
-      DECAF_UNIMPLEMENTED();
-    }
-
-    // Replace this with implementation in cpp file as we go
-    ExecutionResult visitAdd(llvm::BinaryOperator& op);
-    ExecutionResult visitSub(llvm::BinaryOperator& op);
-    ExecutionResult visitMul(llvm::BinaryOperator& op);
-    ExecutionResult visitUDiv(llvm::BinaryOperator& op);
-    ExecutionResult visitSDiv(llvm::BinaryOperator& op);
-    ExecutionResult visitURem(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
-    ExecutionResult visitSRem(llvm::BinaryOperator& op) { DECAF_UNIMPLEMENTED(); }
-
-    ExecutionResult visitICmpInst(llvm::ICmpInst& icmp);
-
-    ExecutionResult visitPHINode(llvm::PHINode& node);
-    ExecutionResult visitBranchInst(llvm::BranchInst& inst);
-    ExecutionResult visitReturnInst(llvm::ReturnInst& inst);
-    ExecutionResult visitCallInst(llvm::CallInst& inst) { DECAF_UNIMPLEMENTED(); }
-  };
+  StackFrame(llvm::Function *function);
 
   /**
-   * Get the Z3 sort corresponding to the provided LLVM type.
+   * Insert a new value into the current stack frame. If that value
+   * is already in the current stack frame then it overwrites it.
+   */
+  void insert(llvm::Value *value, const z3::expr &expr);
+  /**
+   * Lookup a value within the current stack frame.
    *
-   * Only works for supported scalar values at the moment
-   * (i.e. only integers).
+   * There are two main cases here:
+   * 1. `value` is an existing variable
+   * 2. `value` is a constant
    *
-   * Invalid types will result in an assertion.
+   * In the first case we just look up the variable the `variables` map
+   * and then return it. In the second case we build a Z3 expression
+   * that represents the constant and return that.
+   *
+   * This method should be preferred over directly interacting with
+   * `variables` as it correctly handles constants.
    */
-  z3::sort sort_for_type(z3::context& ctx, llvm::Type* type);
+  z3::expr lookup(llvm::Value *value, z3::context &ctx) const;
+}; // namespace decaf
+
+class Context {
+public:
+  std::vector<StackFrame> stack;
+  z3::solver solver;
+
+private:
+  Context(const Context &ctx, z3::solver &&solver);
+
+public:
+  Context(z3::context &z3, llvm::Function *function);
 
   /**
-   * Executes the given function symbolically.
-   *
-   * Currently this works by making all the function arguments symbolic.
-   * Assertion failures during symbolic execution will result in the
-   * model being printed to stdout.
-   *
-   * Note: This is probably good enough for the prototype but we should
-   *       definitely refine the interface as we figure out the best API
-   *       for this.
+   * Create a new context that is independant from this
+   * one but has the same state.
    */
-  void execute_symbolic(llvm::Function* function);
+  Context fork() const;
 
   /**
-   * Create a Z3 expression with the same value as the given constant.
-   * 
-   * Currently only supports integers and will abort on any other LLVM
-   * type.
+   * Get the top frame of the stack.
+   *
+   * This should be used instead of directly manipulating the stack
+   * vector so that it continues to work when more advanced data
+   * structures are implemented.
    */
-  z3::expr evaluate_constant(z3::context& ctx, llvm::Constant* constant);
+  StackFrame &stack_top();
 
   /**
-   * Normalize a Z3 expression to represent 1-bit integers as booleans.
-   * Doesn't affect any other expression type.
-   * 
-   * Justification
-   * =============
-   * LLVM represents booleans using 1-bit integers and most of the time
-   * they're being used as booleans so we need some conversion methods
-   * for when we have one and need the other.
+   * Check whether the current set of assertions + the given expression
+   * is satisfiable.
+   *
+   * Does not modify the solver state. If this returns sat then you can
+   * get the solver model as a test case.
+   *
+   * This will cause an assertion failure if expr is not either a boolean
+   * or a 1-bit integer. 1-bit integers will be implicitly converted to
+   * a boolean.
    */
-  z3::expr normalize_to_bool(const z3::expr& expr);
+  z3::check_result check(const z3::expr &expr);
   /**
-   * Normalize a Z3 expression to represent booleans as integers.
-   * Doesn't affect any other expression type.
-   * 
-   * Justification
-   * =============
-   * LLVM represents booleans using 1-bit integers and most of the time
-   * they're being used as booleans so we need some conversion methods
-   * for when we have one and need the other.
+   * Check whether the current set of assertions is satisifiable.
+   *
+   * If this returns sat then you can extract a model by calling
+   * `solver.model()`.
    */
-  z3::expr normalize_to_int(const z3::expr& expr);
-}
+  z3::check_result check();
+
+  /**
+   * Add a new assertion to the solver.
+   */
+  void add(const z3::expr &assertion);
+};
+
+class Executor {
+private:
+  std::vector<Context> contexts;
+
+public:
+  // The current context has forked and the fork needs to be added
+  // to the queue.
+  void add_context(Context &&ctx);
+
+  // The current context has encountered a failure that needs to be
+  // recorded.
+  void add_failure(const z3::model &model);
+
+  // Get the next context to be executed.
+  Context next_context();
+
+  // Are there any contexts left?
+  bool has_next() const;
+};
+
+enum class ExecutionResult { Continue, Stop };
+
+class Interpreter : public llvm::InstVisitor<Interpreter, ExecutionResult> {
+private:
+  Context *ctx;
+  Executor *queue;
+  z3::context *z3;
+
+public:
+  // Add some more parameters here
+  Interpreter(Context *ctx, Executor *queue, z3::context *z3);
+
+  /**
+   * Execute this interpreter's context until it finishes.
+   *
+   * Contexts from forks will be placed into the execution queue.
+   * Failures resulting from this context will also be added to
+   * the execution queue.
+   */
+  void execute();
+
+  // Marks an unimplemented instruction.
+  //
+  // TODO: Better error message?
+  ExecutionResult visitInstruction(llvm::Instruction &) {
+    DECAF_UNIMPLEMENTED();
+  }
+
+  // Replace this with implementation in cpp file as we go
+  ExecutionResult visitAdd(llvm::BinaryOperator &op);
+  ExecutionResult visitSub(llvm::BinaryOperator &op);
+  ExecutionResult visitMul(llvm::BinaryOperator &op);
+  ExecutionResult visitUDiv(llvm::BinaryOperator &op);
+  ExecutionResult visitSDiv(llvm::BinaryOperator &op);
+  ExecutionResult visitURem(llvm::BinaryOperator &op) {
+    DECAF_UNIMPLEMENTED();
+  }
+  ExecutionResult visitSRem(llvm::BinaryOperator &op) {
+    DECAF_UNIMPLEMENTED();
+  }
+
+  ExecutionResult visitICmpInst(llvm::ICmpInst &icmp);
+
+  ExecutionResult visitPHINode(llvm::PHINode &node);
+  ExecutionResult visitBranchInst(llvm::BranchInst &inst);
+  ExecutionResult visitReturnInst(llvm::ReturnInst &inst);
+  ExecutionResult visitCallInst(llvm::CallInst &inst) {
+    DECAF_UNIMPLEMENTED();
+  }
+};
+
+/**
+ * Get the Z3 sort corresponding to the provided LLVM type.
+ *
+ * Only works for supported scalar values at the moment
+ * (i.e. only integers).
+ *
+ * Invalid types will result in an assertion.
+ */
+z3::sort sort_for_type(z3::context &ctx, llvm::Type *type);
+
+/**
+ * Executes the given function symbolically.
+ *
+ * Currently this works by making all the function arguments symbolic.
+ * Assertion failures during symbolic execution will result in the
+ * model being printed to stdout.
+ *
+ * Note: This is probably good enough for the prototype but we should
+ *       definitely refine the interface as we figure out the best API
+ *       for this.
+ */
+void execute_symbolic(llvm::Function *function);
+
+/**
+ * Create a Z3 expression with the same value as the given constant.
+ *
+ * Currently only supports integers and will abort on any other LLVM
+ * type.
+ */
+z3::expr evaluate_constant(z3::context &ctx, llvm::Constant *constant);
+
+/**
+ * Normalize a Z3 expression to represent 1-bit integers as booleans.
+ * Doesn't affect any other expression type.
+ *
+ * Justification
+ * =============
+ * LLVM represents booleans using 1-bit integers and most of the time
+ * they're being used as booleans so we need some conversion methods
+ * for when we have one and need the other.
+ */
+z3::expr normalize_to_bool(const z3::expr &expr);
+/**
+ * Normalize a Z3 expression to represent booleans as integers.
+ * Doesn't affect any other expression type.
+ *
+ * Justification
+ * =============
+ * LLVM represents booleans using 1-bit integers and most of the time
+ * they're being used as booleans so we need some conversion methods
+ * for when we have one and need the other.
+ */
+z3::expr normalize_to_int(const z3::expr &expr);
+} // namespace decaf

--- a/include/macros.h
+++ b/include/macros.h
@@ -5,98 +5,79 @@
 #include <string_view>
 
 namespace decaf {
-  namespace detail {
-    /** Optional-like type for use in message creation.
-     * 
-     * I'm trying to keep this header lightweight so that including it
-     * everywhere is less of an issue.
-     * 
-     * This struct should not usually be used directly. Use one of the
-     * assertion or abortion macros instead.
-     */
-    struct message {
-      bool has_value;
-      std::string_view msg;
+namespace detail {
+  /** Optional-like type for use in message creation.
+   *
+   * I'm trying to keep this header lightweight so that including it
+   * everywhere is less of an issue.
+   *
+   * This struct should not usually be used directly. Use one of the
+   * assertion or abortion macros instead.
+   */
+  struct message {
+    bool has_value;
+    std::string_view msg;
 
-      message() : has_value(false) {}
-      message(std::string_view msg) : has_value(true), msg(msg) {}
-    };
+    message() : has_value(false) {}
+    message(std::string_view msg) : has_value(true), msg(msg) {}
+  };
 
-    /**
-     * Exit the process with an "assertion failed" message and print a
-     * backtrace of where the assertion failed.
-     * 
-     * Usually, this function should not be called directly. Use
-     * DECAF_ASSERT instead.
-     */
-    [[noreturn]] void assert_fail(
-      const char* condition,
-      const char* function,
-      unsigned int line,
-      const char* file,
-      message message
-    );
+  /**
+   * Exit the process with an "assertion failed" message and print a
+   * backtrace of where the assertion failed.
+   *
+   * Usually, this function should not be called directly. Use
+   * DECAF_ASSERT instead.
+   */
+  [[noreturn]] void assert_fail(const char *condition, const char *function, unsigned int line,
+                                const char *file, message message);
 
-    /**
-     * Exit the process with an abort message and print a backtrace of
-     * where the process aborted.
-     * 
-     * Usually, this function should not be called directly. Use DECAF_ABORT
-     * or one of the other abortion macros such as DECAF_UNIMPLEMENTED or
-     * DECAF_UNREACHABLE instead.
-     */
-    [[noreturn]] void abort(
-      const char* function,
-      unsigned int line,
-      const char* file,
-      message message
-    );
-  }
-}
+  /**
+   * Exit the process with an abort message and print a backtrace of
+   * where the process aborted.
+   *
+   * Usually, this function should not be called directly. Use DECAF_ABORT
+   * or one of the other abortion macros such as DECAF_UNIMPLEMENTED or
+   * DECAF_UNREACHABLE instead.
+   */
+  [[noreturn]] void abort(const char *function, unsigned int line, const char *file,
+                          message message);
+} // namespace detail
+} // namespace decaf
 
 #ifdef __PRETTY_FUNCTION__
-#  define DECAF_FUNCTION __PRETTY_FUNCTION__
+#define DECAF_FUNCTION __PRETTY_FUNCTION__
 #else
-#  define DECAF_FUNCTION __FUNCTION__
+#define DECAF_FUNCTION __FUNCTION__
 #endif
 
 /**
  * Abort the process if the condition is not true.
- * 
+ *
  * There are two valid forms for this assert macro
  * ```
  * DECAF_ASSERT(cond);
  * DECAF_ASSERT(cond, "some message");
  * ```
- * 
+ *
  * The only difference is that the first one uses a default message and the
  * second one uses the provided message when it fails.
- * 
+ *
  * Note that the message is only evaluated if the assertion fails.
  */
-#define DECAF_ASSERT(cond, ...)               \
-  do {                                        \
-    if (!(cond)) {                            \
-      ::decaf::detail::assert_fail(           \
-        #cond,                                \
-        DECAF_FUNCTION,                       \
-        __LINE__,                             \
-        __FILE__,                             \
-        ::decaf::detail::message(__VA_ARGS__) \
-      );                                      \
-    }                                         \
+#define DECAF_ASSERT(cond, ...)                                                                    \
+  do {                                                                                             \
+    if (!(cond)) {                                                                                 \
+      ::decaf::detail::assert_fail(#cond, DECAF_FUNCTION, __LINE__, __FILE__,                      \
+                                   ::decaf::detail::message(__VA_ARGS__));                         \
+    }                                                                                              \
   } while (false)
 
 /**
  * Abort the process with an optional message.
  */
-#define DECAF_ABORT(...)                  \
-  ::decaf::detail::abort(                 \
-    DECAF_FUNCTION,                       \
-    __LINE__,                             \
-    __FILE__,                             \
-    ::decaf::detail::message(__VA_ARGS__) \
-  )
+#define DECAF_ABORT(...)                                                                           \
+  ::decaf::detail::abort(DECAF_FUNCTION, __LINE__, __FILE__, ::decaf::detail::message(__VA_ARGS__))
 
 // Abort the process with a message about unreachable code
 #define DECAF_UNREACHABLE() DECAF_ABORT("entered unreachable code")

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -4,59 +4,44 @@
 #include <boost/core/demangle.hpp>
 #include <boost/stacktrace.hpp>
 
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 namespace decaf::detail {
-  [[noreturn]] void assert_fail(
-    const char* condition,
-    const char* function,
-    unsigned int line,
-    const char* file,
-    message message
-  ) {
-    auto stacktrace = boost::stacktrace::stacktrace();
-    auto demangled = boost::core::demangle(function);
+[[noreturn]] void assert_fail(const char *condition, const char *function, unsigned int line,
+                              const char *file, message message) {
+  auto stacktrace = boost::stacktrace::stacktrace();
+  auto demangled = boost::core::demangle(function);
 
-    std::cerr
-      << "Assertion failed: " << condition << "\n"
-      << "  location: " << file << ":" << line << "\n"
-      << "  function: " << demangled << "\n";
+  std::cerr << "Assertion failed: " << condition << "\n"
+            << "  location: " << file << ":" << line << "\n"
+            << "  function: " << demangled << "\n";
 
-    if (message.has_value) {
-      std::cerr << "  message: " << message.msg << "\n";
-    }
-
-    std::cerr
-      << "\n"
-      << stacktrace << "\n";
-
-    std::exit(255);
+  if (message.has_value) {
+    std::cerr << "  message: " << message.msg << "\n";
   }
 
-  [[noreturn]] void abort(
-    const char* function,
-    unsigned int line,
-    const char* file,
-    message message
-  ) {
-    auto stacktrace = boost::stacktrace::stacktrace();
-    auto demangled = boost::core::demangle(function);
+  std::cerr << "\n" << stacktrace << "\n";
 
-    if (message.has_value) {
-      std::cerr
-        << "Aborted with message: " << message.msg << "\n"
-        << "  location: " << file << ":" << line << "\n";
-    } else {
-      std::cerr << "Aborted at " << file << ":" << line << "\n"; 
-    }
-
-    std::cerr
-      << "  function: " << demangled << "\n"
-      << "  Stack Trace:\n"
-      << stacktrace
-      << "\n";
-
-    std::exit(255);
-  }
+  std::exit(255);
 }
+
+[[noreturn]] void abort(const char *function, unsigned int line, const char *file,
+                        message message) {
+  auto stacktrace = boost::stacktrace::stacktrace();
+  auto demangled = boost::core::demangle(function);
+
+  if (message.has_value) {
+    std::cerr << "Aborted with message: " << message.msg << "\n"
+              << "  location: " << file << ":" << line << "\n";
+  } else {
+    std::cerr << "Aborted at " << file << ":" << line << "\n";
+  }
+
+  std::cerr << "  function: " << demangled << "\n"
+            << "  Stack Trace:\n"
+            << stacktrace << "\n";
+
+  std::exit(255);
+}
+} // namespace decaf::detail

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -6,411 +6,399 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <iostream>
-#include <stdexcept>
 #include <optional>
+#include <stdexcept>
 
 namespace decaf {
-  /************************************************
-   * Executor                                     *
-   ************************************************/
-  void Executor::add_context(Context&& ctx) {
-    contexts.push_back(ctx);
-  }
-
-  void Executor::add_failure(const z3::model& model) {
-    // TODO: It might not be necessary for the prototype but we'll need
-    //       to figure what we want to do with test failures.
-    std::cout
-      << "Found failed model! Inputs: \n"
-      << model << std::endl;
-  }
-
-  Context Executor::next_context() {
-    DECAF_ASSERT(has_next());
-
-    Context ctx = std::move(contexts.back());
-    contexts.pop_back();
-    return ctx;
-  }
-
-  bool Executor::has_next() const {
-    return !contexts.empty();
-  }
-
-  /************************************************
-   * StackFrame                                   *
-   ************************************************/
-  StackFrame::StackFrame(llvm::Function* function) :
-    function(function),
-    current_block(&function->getEntryBlock()),
-    prev_block(nullptr),
-    current(current_block->begin())
-  {}
-  
-  void StackFrame::insert(llvm::Value* value, const z3::expr& expr) {
-    variables.insert_or_assign(value, expr);
-  }
-
-  z3::expr StackFrame::lookup(llvm::Value* value, z3::context& ctx) const {
-    if (auto* constant = llvm::dyn_cast_or_null<llvm::Constant>(value))
-      return evaluate_constant(ctx, constant);
-    
-    auto it = variables.find(value);
-    DECAF_ASSERT(it != variables.end(), "Tried to access unknown variable");
-    return it->second;
-  }
-
-  /************************************************
-   * Context                                      *
-   ************************************************/
-  Context::Context(z3::context& z3, llvm::Function* function) :
-    solver(z3)
-  {
-    stack.emplace_back(function);
-    StackFrame& frame = stack_top();
-
-    int argnum = 0;
-    for (auto& arg : function->args()) {
-      z3::sort sort = sort_for_type(z3, arg.getType());
-      z3::symbol symbol = z3.int_symbol(argnum);
-
-      frame.variables.insert({ &arg, z3.constant(symbol, sort) });
-      argnum += 1;
-    }
-  }
-  Context::Context(const Context& ctx, z3::solver&& solver) :
-    Context(ctx)
-  {
-    solver = std::move(solver);
-  }
-
-  StackFrame& Context::stack_top() {
-    DECAF_ASSERT(!stack.empty());
-    return stack.back();
-  }
-
-  z3::check_result Context::check(const z3::expr& expr) {
-    auto cond = normalize_to_bool(expr);
-    DECAF_ASSERT(cond.is_bool());
-    return solver.check(1, &cond);
-  }
-  z3::check_result Context::check() {
-    return solver.check();
-  }
-
-  void Context::add(const z3::expr& assertion) {
-    solver.add(assertion);
-  }
-
-  Context Context::fork() const {
-    z3::solver new_solver{solver.ctx()};
-
-    for (const auto& assertion : solver.assertions()) {
-      new_solver.add(assertion);
-    }
-    
-    return Context(*this, std::move(new_solver));
-  }
-
-  /************************************************
-   * Interpreter                                  *
-   ************************************************/
-  Interpreter::Interpreter(Context* ctx, Executor* queue, z3::context* z3) :
-    ctx(ctx), queue(queue), z3(z3)
-  {}
-
-  void Interpreter::execute() {
-    ExecutionResult exec;
-
-    do {
-      StackFrame& frame = ctx->stack_top();
-
-      DECAF_ASSERT(
-        frame.current != frame.current_block->end(),
-        "Instruction pointer ran off end of block.");
-
-      llvm::Instruction& inst = *frame.current;
-
-      // Note: Need to increment the iterator before actually doing
-      //       anything with the instruction since instructions can
-      //       modify the current position (e.g. branch, call, etc.)
-      ++frame.current;
-
-      exec = visit(inst);
-    } while (exec == ExecutionResult::Continue);
-  }
-
-  /************************************************
-   * Free Functions                               *
-   ************************************************/
-  z3::sort sort_for_type(z3::context& ctx, llvm::Type* type) {
-    if (type->isIntegerTy()) {
-      return ctx.bv_sort(type->getIntegerBitWidth());
-    }
-
-    std::string message;
-    llvm::raw_string_ostream os{message};
-    os << "Unsupported LLVM type: ";
-    type->print(os);
-
-    DECAF_ABORT(message);
-  }
-
-  void execute_symbolic(llvm::Function* function) {
-    z3::config cfg;
-
-    // We want Z3 to generate models
-    cfg.set("model", true);
-    // Automatically select and configure the solver
-    cfg.set("auto_config", true);
-
-    z3::context z3{cfg};
-    Executor exec;
-
-    exec.add_context(Context(z3, function));
-
-    while (exec.has_next()) {
-      Context ctx = exec.next_context();
-      Interpreter interp{&ctx, &exec, &z3};
-
-      interp.execute();
-    }
-  }
-  
-  ExecutionResult Interpreter::visitAdd(llvm::BinaryOperator& op) {
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
-
-    frame.insert(&op, lhs + rhs);
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitSub(llvm::BinaryOperator& op) {
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
-
-    frame.insert(&op, lhs - rhs);
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitMul(llvm::BinaryOperator& op) {
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
-
-    frame.insert(&op, lhs * rhs);
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator& op) {
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
-
-    if (ctx->check(rhs == 0 || !z3::bvsdiv_no_overflow(lhs, rhs)) == z3::sat) {
-      queue->add_failure(ctx->solver.get_model());
-    }
-    ctx->add(rhs != 0);
-    ctx->add(z3::bvsdiv_no_overflow(lhs, rhs));
-
-    frame.insert(&op, lhs / rhs);
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator& op) {
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
-
-    if (ctx->check(rhs == 0) == z3::sat) {
-      queue->add_failure(ctx->solver.get_model());
-    }
-    ctx->add(rhs != 0);
-
-    frame.insert(&op, lhs / rhs);
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitICmpInst(llvm::ICmpInst& icmp) {
-    using llvm::ICmpInst;
-
-    StackFrame& frame = ctx->stack_top();
-
-    auto lhs = normalize_to_int(frame.lookup(icmp.getOperand(0), *z3));
-    auto rhs = normalize_to_int(frame.lookup(icmp.getOperand(1), *z3));
-
-    switch (icmp.getPredicate()) {
-    case ICmpInst::ICMP_EQ:
-      frame.insert(&icmp, lhs == rhs);
-      break;
-    case ICmpInst::ICMP_NE:
-      frame.insert(&icmp, lhs != rhs);
-      break;
-    case ICmpInst::ICMP_UGT:
-      frame.insert(&icmp, z3::ugt(lhs, rhs));
-      break;
-    case ICmpInst::ICMP_UGE:
-      frame.insert(&icmp, z3::uge(lhs, rhs));
-      break;
-    case ICmpInst::ICMP_ULT:
-      frame.insert(&icmp, z3::ult(lhs, rhs));
-      break;
-    case ICmpInst::ICMP_ULE:
-      frame.insert(&icmp, z3::ule(lhs, rhs));
-      break;
-    case ICmpInst::ICMP_SGT:
-      frame.insert(&icmp, lhs > rhs);
-      break;
-    case ICmpInst::ICMP_SGE:
-      frame.insert(&icmp, lhs >= rhs);
-      break;
-    case ICmpInst::ICMP_SLT:
-      frame.insert(&icmp, lhs < rhs);
-      break;
-    case ICmpInst::ICMP_SLE:
-      frame.insert(&icmp, lhs <= rhs);
-      break;
-    default:
-      DECAF_UNREACHABLE();
-    }
-  
-    return ExecutionResult::Continue;
-  }
-
-
-  ExecutionResult Interpreter::visitBranchInst(llvm::BranchInst& inst) {
-    auto jump_to = [&](llvm::BasicBlock* target) {
-      auto& frame = ctx->stack_top();
-      frame.prev_block = frame.current_block;
-      frame.current_block = target;
-    };
-    
-    if (!inst.isConditional()) {
-      jump_to(inst.getSuccessor(0));
-      return ExecutionResult::Continue;
-    }
-
-    auto& frame = ctx->stack_top();
-    auto cond = normalize_to_bool(frame.lookup(inst.getCondition(), *z3));
-
-    auto is_t = ctx->check(cond);
-    auto is_f = ctx->check(!cond);
-
-    // Note: For the purposes of branching we consider unknown to be
-    //       equivalent to sat. Maybe future branches will bring the
-    //       equation back to being solvable.
-    if (is_t != z3::unsat && is_f != z3::unsat) {
-      auto fork = ctx->fork();
-
-      // In cases where both conditions are possible we follow the
-      // false path. This should be enough to get us out of most loops
-      // and actually exploring the rest of the program.
-      fork.add(cond);
-      ctx->add(!cond);
-
-      queue->add_context(std::move(fork));
-      return ExecutionResult::Continue;
-    } else if (is_t != z3::unsat) {
-      ctx->add(cond);
-      return ExecutionResult::Continue;
-    } else if (is_f != z3::unsat) {
-      ctx->add(!cond);
-      return ExecutionResult::Continue;
-    } else {
-      return ExecutionResult::Stop;
-    }
-  }
-
-  ExecutionResult Interpreter::visitReturnInst(llvm::ReturnInst& inst) {
-    auto& frame = ctx->stack_top();
-
-    std::optional<z3::expr> result;
-    if (inst.getNumOperands() != 0)
-      result = frame.lookup(inst.getOperand(0), *z3);
-
-    ctx->stack.pop_back();
-
-    // Reached end of function, nothing left to do.
-    if (ctx->stack.empty())
-      return ExecutionResult::Stop;
-
-    if (result.has_value()) {
-      auto& parent = ctx->stack_top();
-      auto& caller = *std::prev(parent.current);
-
-      parent.insert(&caller, *result);
-    }
-
-    return ExecutionResult::Continue;
-  }
-
-  ExecutionResult Interpreter::visitPHINode(llvm::PHINode& node) {
-    auto& frame = ctx->stack_top();
-
-    // PHI nodes in the entry block is invalid.
-    DECAF_ASSERT(frame.prev_block != nullptr);
-
-    auto value = frame.lookup(node.getIncomingValueForBlock(frame.prev_block), *z3);
-    frame.insert(&node, value);
-
-    return ExecutionResult::Continue;
-  }
-
-  z3::expr evaluate_constant(z3::context& ctx, llvm::Constant* constant) {
-    if (auto* intconst = llvm::dyn_cast<llvm::ConstantInt>(constant)) {
-      const llvm::APInt& value = intconst->getValue();
-
-      if (value.getBitWidth() <= 64) {
-        return ctx.bv_val(value.getLimitedValue(), value.getBitWidth());
-      } 
-
-      // This isn't particularly efficient. Unfortunately, when it comes
-      // to integers larger than uint64_t there's no efficient way to get
-      // them into Z3. The options are either
-      //  - Convert to base-10 string and use that
-      //  - Put every single bit into a separate boolean then load that
-      // I've opted to go the string route since it's easier here. Maybe
-      // in the future we can get an API for doing this more efficiently
-      // added to Z3.
-      llvm::SmallString<64> str;
-      value.toStringUnsigned(str, 10);
-
-      return ctx.bv_val(str.c_str(), value.getBitWidth());
-    }
-
-    // We only implement integers at the moment
-    DECAF_UNIMPLEMENTED();
-  }
-
-  z3::expr normalize_to_bool(const z3::expr& expr) {
-    auto sort = expr.get_sort();
-
-    if (sort.is_int() && sort.bv_size() == 1)
-      return expr == 1;
-
-    return expr;
-  }
-
-  z3::expr normalize_to_int(const z3::expr& expr) {
-    auto sort = expr.get_sort();
-
-    if (sort.is_bool()) {
-      auto& ctx = expr.ctx();
-      return z3::ite(expr, ctx.bv_val(1, 1), ctx.bv_val(0, 1));
-    }
-
-    return expr;
+/************************************************
+ * Executor                                     *
+ ************************************************/
+void Executor::add_context(Context &&ctx) {
+  contexts.push_back(ctx);
+}
+
+void Executor::add_failure(const z3::model &model) {
+  // TODO: It might not be necessary for the prototype but we'll need
+  //       to figure what we want to do with test failures.
+  std::cout << "Found failed model! Inputs: \n" << model << std::endl;
+}
+
+Context Executor::next_context() {
+  DECAF_ASSERT(has_next());
+
+  Context ctx = std::move(contexts.back());
+  contexts.pop_back();
+  return ctx;
+}
+
+bool Executor::has_next() const {
+  return !contexts.empty();
+}
+
+/************************************************
+ * StackFrame                                   *
+ ************************************************/
+StackFrame::StackFrame(llvm::Function *function)
+    : function(function), current_block(&function->getEntryBlock()), prev_block(nullptr),
+      current(current_block->begin()) {}
+
+void StackFrame::insert(llvm::Value *value, const z3::expr &expr) {
+  variables.insert_or_assign(value, expr);
+}
+
+z3::expr StackFrame::lookup(llvm::Value *value, z3::context &ctx) const {
+  if (auto *constant = llvm::dyn_cast_or_null<llvm::Constant>(value))
+    return evaluate_constant(ctx, constant);
+
+  auto it = variables.find(value);
+  DECAF_ASSERT(it != variables.end(), "Tried to access unknown variable");
+  return it->second;
+}
+
+/************************************************
+ * Context                                      *
+ ************************************************/
+Context::Context(z3::context &z3, llvm::Function *function) : solver(z3) {
+  stack.emplace_back(function);
+  StackFrame &frame = stack_top();
+
+  int argnum = 0;
+  for (auto &arg : function->args()) {
+    z3::sort sort = sort_for_type(z3, arg.getType());
+    z3::symbol symbol = z3.int_symbol(argnum);
+
+    frame.variables.insert({&arg, z3.constant(symbol, sort)});
+    argnum += 1;
   }
 }
+Context::Context(const Context &ctx, z3::solver &&solver) : Context(ctx) {
+  solver = std::move(solver);
+}
+
+StackFrame &Context::stack_top() {
+  DECAF_ASSERT(!stack.empty());
+  return stack.back();
+}
+
+z3::check_result Context::check(const z3::expr &expr) {
+  auto cond = normalize_to_bool(expr);
+  DECAF_ASSERT(cond.is_bool());
+  return solver.check(1, &cond);
+}
+z3::check_result Context::check() {
+  return solver.check();
+}
+
+void Context::add(const z3::expr &assertion) {
+  solver.add(assertion);
+}
+
+Context Context::fork() const {
+  z3::solver new_solver{solver.ctx()};
+
+  for (const auto &assertion : solver.assertions()) {
+    new_solver.add(assertion);
+  }
+
+  return Context(*this, std::move(new_solver));
+}
+
+/************************************************
+ * Interpreter                                  *
+ ************************************************/
+Interpreter::Interpreter(Context *ctx, Executor *queue, z3::context *z3)
+    : ctx(ctx), queue(queue), z3(z3) {}
+
+void Interpreter::execute() {
+  ExecutionResult exec;
+
+  do {
+    StackFrame &frame = ctx->stack_top();
+
+    DECAF_ASSERT(frame.current != frame.current_block->end(),
+                 "Instruction pointer ran off end of block.");
+
+    llvm::Instruction &inst = *frame.current;
+
+    // Note: Need to increment the iterator before actually doing
+    //       anything with the instruction since instructions can
+    //       modify the current position (e.g. branch, call, etc.)
+    ++frame.current;
+
+    exec = visit(inst);
+  } while (exec == ExecutionResult::Continue);
+}
+
+/************************************************
+ * Free Functions                               *
+ ************************************************/
+z3::sort sort_for_type(z3::context &ctx, llvm::Type *type) {
+  if (type->isIntegerTy()) {
+    return ctx.bv_sort(type->getIntegerBitWidth());
+  }
+
+  std::string message;
+  llvm::raw_string_ostream os{message};
+  os << "Unsupported LLVM type: ";
+  type->print(os);
+
+  DECAF_ABORT(message);
+}
+
+void execute_symbolic(llvm::Function *function) {
+  z3::config cfg;
+
+  // We want Z3 to generate models
+  cfg.set("model", true);
+  // Automatically select and configure the solver
+  cfg.set("auto_config", true);
+
+  z3::context z3{cfg};
+  Executor exec;
+
+  exec.add_context(Context(z3, function));
+
+  while (exec.has_next()) {
+    Context ctx = exec.next_context();
+    Interpreter interp{&ctx, &exec, &z3};
+
+    interp.execute();
+  }
+}
+
+ExecutionResult Interpreter::visitAdd(llvm::BinaryOperator &op) {
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
+
+  frame.insert(&op, lhs + rhs);
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitSub(llvm::BinaryOperator &op) {
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
+
+  frame.insert(&op, lhs - rhs);
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitMul(llvm::BinaryOperator &op) {
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
+
+  frame.insert(&op, lhs * rhs);
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitICmpInst(llvm::ICmpInst &icmp) {
+  using llvm::ICmpInst;
+
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(icmp.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(icmp.getOperand(1), *z3));
+
+  switch (icmp.getPredicate()) {
+  case ICmpInst::ICMP_EQ:
+    frame.insert(&icmp, lhs == rhs);
+    break;
+  case ICmpInst::ICMP_NE:
+    frame.insert(&icmp, lhs != rhs);
+    break;
+  case ICmpInst::ICMP_UGT:
+    frame.insert(&icmp, z3::ugt(lhs, rhs));
+    break;
+  case ICmpInst::ICMP_UGE:
+    frame.insert(&icmp, z3::uge(lhs, rhs));
+    break;
+  case ICmpInst::ICMP_ULT:
+    frame.insert(&icmp, z3::ult(lhs, rhs));
+    break;
+  case ICmpInst::ICMP_ULE:
+    frame.insert(&icmp, z3::ule(lhs, rhs));
+    break;
+  case ICmpInst::ICMP_SGT:
+    frame.insert(&icmp, lhs > rhs);
+    break;
+  case ICmpInst::ICMP_SGE:
+    frame.insert(&icmp, lhs >= rhs);
+    break;
+  case ICmpInst::ICMP_SLT:
+    frame.insert(&icmp, lhs < rhs);
+    break;
+  case ICmpInst::ICMP_SLE:
+    frame.insert(&icmp, lhs <= rhs);
+    break;
+  default:
+    DECAF_UNREACHABLE();
+  }
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitSDiv(llvm::BinaryOperator &op) {
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
+
+  if (ctx->check(rhs == 0 || !z3::bvsdiv_no_overflow(lhs, rhs)) == z3::sat) {
+    queue->add_failure(ctx->solver.get_model());
+  }
+  ctx->add(rhs != 0);
+  ctx->add(z3::bvsdiv_no_overflow(lhs, rhs));
+
+  frame.insert(&op, lhs / rhs);
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitUDiv(llvm::BinaryOperator &op) {
+  StackFrame &frame = ctx->stack_top();
+
+  auto lhs = normalize_to_int(frame.lookup(op.getOperand(0), *z3));
+  auto rhs = normalize_to_int(frame.lookup(op.getOperand(1), *z3));
+
+  if (ctx->check(rhs == 0) == z3::sat) {
+    queue->add_failure(ctx->solver.get_model());
+  }
+  ctx->add(rhs != 0);
+
+  frame.insert(&op, lhs / rhs);
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitBranchInst(llvm::BranchInst &inst) {
+  auto jump_to = [&](llvm::BasicBlock *target) {
+    auto &frame = ctx->stack_top();
+    frame.prev_block = frame.current_block;
+    frame.current_block = target;
+  };
+
+  if (!inst.isConditional()) {
+    jump_to(inst.getSuccessor(0));
+    return ExecutionResult::Continue;
+  }
+
+  auto &frame = ctx->stack_top();
+  auto cond = normalize_to_bool(frame.lookup(inst.getCondition(), *z3));
+
+  auto is_t = ctx->check(cond);
+  auto is_f = ctx->check(!cond);
+
+  // Note: For the purposes of branching we consider unknown to be
+  //       equivalent to sat. Maybe future branches will bring the
+  //       equation back to being solvable.
+  if (is_t != z3::unsat && is_f != z3::unsat) {
+    auto fork = ctx->fork();
+
+    // In cases where both conditions are possible we follow the
+    // false path. This should be enough to get us out of most loops
+    // and actually exploring the rest of the program.
+    fork.add(cond);
+    ctx->add(!cond);
+
+    queue->add_context(std::move(fork));
+    return ExecutionResult::Continue;
+  } else if (is_t != z3::unsat) {
+    ctx->add(cond);
+    return ExecutionResult::Continue;
+  } else if (is_f != z3::unsat) {
+    ctx->add(!cond);
+    return ExecutionResult::Continue;
+  } else {
+    return ExecutionResult::Stop;
+  }
+}
+
+ExecutionResult Interpreter::visitReturnInst(llvm::ReturnInst &inst) {
+  auto &frame = ctx->stack_top();
+
+  std::optional<z3::expr> result;
+  if (inst.getNumOperands() != 0)
+    result = frame.lookup(inst.getOperand(0), *z3);
+
+  ctx->stack.pop_back();
+
+  // Reached end of function, nothing left to do.
+  if (ctx->stack.empty())
+    return ExecutionResult::Stop;
+
+  if (result.has_value()) {
+    auto &parent = ctx->stack_top();
+    auto &caller = *std::prev(parent.current);
+
+    parent.insert(&caller, *result);
+  }
+
+  return ExecutionResult::Continue;
+}
+
+ExecutionResult Interpreter::visitPHINode(llvm::PHINode &node) {
+  auto &frame = ctx->stack_top();
+
+  // PHI nodes in the entry block is invalid.
+  DECAF_ASSERT(frame.prev_block != nullptr);
+
+  auto value = frame.lookup(node.getIncomingValueForBlock(frame.prev_block), *z3);
+  frame.insert(&node, value);
+
+  return ExecutionResult::Continue;
+}
+
+z3::expr evaluate_constant(z3::context &ctx, llvm::Constant *constant) {
+  if (auto *intconst = llvm::dyn_cast<llvm::ConstantInt>(constant)) {
+    const llvm::APInt &value = intconst->getValue();
+
+    if (value.getBitWidth() <= 64) {
+      return ctx.bv_val(value.getLimitedValue(), value.getBitWidth());
+    }
+
+    // This isn't particularly efficient. Unfortunately, when it comes
+    // to integers larger than uint64_t there's no efficient way to get
+    // them into Z3. The options are either
+    //  - Convert to base-10 string and use that
+    //  - Put every single bit into a separate boolean then load that
+    // I've opted to go the string route since it's easier here. Maybe
+    // in the future we can get an API for doing this more efficiently
+    // added to Z3.
+    llvm::SmallString<64> str;
+    value.toStringUnsigned(str, 10);
+
+    return ctx.bv_val(str.c_str(), value.getBitWidth());
+  }
+
+  // We only implement integers at the moment
+  DECAF_UNIMPLEMENTED();
+}
+
+z3::expr normalize_to_bool(const z3::expr &expr) {
+  auto sort = expr.get_sort();
+
+  if (sort.is_int() && sort.bv_size() == 1)
+    return expr == 1;
+
+  return expr;
+}
+
+z3::expr normalize_to_int(const z3::expr &expr) {
+  auto sort = expr.get_sort();
+
+  if (sort.is_bool()) {
+    auto &ctx = expr.ctx();
+    return z3::ite(expr, ctx.bv_val(1, 1), ctx.bv_val(0, 1));
+  }
+
+  return expr;
+}
+} // namespace decaf

--- a/tests/common.h
+++ b/tests/common.h
@@ -2,14 +2,14 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
-#include <z3++.h>
 #include <llvm/IR/Function.h>
+#include <z3++.h>
 
 #include <memory>
 
 /**
  * Create a z3 context with the required configuration.
- * 
+ *
  * This should be kept roughly in sync with the context creation
  * within decaf::execute_symbolic.
  */
@@ -17,11 +17,11 @@ z3::context default_context();
 
 /**
  * Creates a function with a single basic block.
- * 
+ *
  * When creating a few simple instructions you should insert them into
  * the provided basic block otherwise you'll get LLVM assertions when
  * attempting to run the tests.
  */
-std::unique_ptr<llvm::Function> empty_function(llvm::LLVMContext& llvm);
+std::unique_ptr<llvm::Function> empty_function(llvm::LLVMContext &llvm);
 
 #endif

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,7 @@
 
 #include <gtest/gtest.h>
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tests/opcodes.cpp
+++ b/tests/opcodes.cpp
@@ -1,8 +1,8 @@
 
 #include <gtest/gtest.h>
 
-#include "decaf.h"
 #include "common.h"
+#include "decaf.h"
 
 #include <llvm/IR/Instructions.h>
 
@@ -10,10 +10,10 @@
 
 using namespace decaf;
 
-using llvm::ConstantInt;
-using llvm::LLVMContext;
-using llvm::IntegerType;
 using llvm::APInt;
+using llvm::ConstantInt;
+using llvm::IntegerType;
+using llvm::LLVMContext;
 
 /**
  * Tests that creating constant integers with bitwidth > 64 works
@@ -24,7 +24,7 @@ TEST(opcodes, large_constant_integer) {
   z3::context z3 = default_context();
 
   unsigned bitwidth = 20000;
-  const char* string = "99999999999999999999999999999999999999999999999999991";
+  const char *string = "99999999999999999999999999999999999999999999999999991";
   auto value = ConstantInt::get(IntegerType::get(llvm, bitwidth), APInt(bitwidth, string, 10));
 
   auto evaluated = decaf::evaluate_constant(z3, value);
@@ -38,7 +38,7 @@ TEST(opcodes, large_constant_integer) {
 
 /**
  * Test that 7 + 9 + 5 == 21.
- * 
+ *
  * This tests that
  * 1. Creating integer constants works properly.
  * 2. Addition instructions with only constant operands work properly.
@@ -57,7 +57,7 @@ TEST(opcodes, basic_add_test) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto add1 = llvm::BinaryOperator::CreateAdd(val1, val2, "add1", &bb);
   auto add2 = llvm::BinaryOperator::CreateAdd(add1, val3, "add2", &bb);
 
@@ -80,9 +80,9 @@ TEST(opcodes, basic_sub_test) {
   auto val1 = ConstantInt::get(IntegerType::getInt32Ty(llvm), APInt(32, 7));
   auto val2 = ConstantInt::get(IntegerType::getInt32Ty(llvm), APInt(32, 9));
   auto val3 = ConstantInt::get(IntegerType::getInt32Ty(llvm), APInt(32, (uint64_t)(-5)));
-  
+
   Interpreter interp{&ctx, nullptr, &z3};
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
 
   auto sub1 = llvm::BinaryOperator::CreateSub(val1, val2, "sub1", &bb);
   auto sub2 = llvm::BinaryOperator::CreateSub(sub1, val3, "sub2", &bb);
@@ -107,11 +107,11 @@ TEST(opcodes, 1bit_add_test) {
   auto val0 = ConstantInt::get(IntegerType::getInt1Ty(llvm), APInt(1, 0));
   auto val1 = ConstantInt::get(IntegerType::getInt1Ty(llvm), APInt(1, 1));
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   // We'll never actually use this value, just need a non-constant value
   // type that we can manually insert into the context.
   auto dummy = llvm::BinaryOperator::CreateAdd(val0, val1, "dummy", &bb);
-  
+
   auto add0 = llvm::BinaryOperator::CreateAdd(dummy, val0, "add0", &bb);
   auto add1 = llvm::BinaryOperator::CreateAdd(dummy, val1, "add1", &bb);
 
@@ -123,7 +123,7 @@ TEST(opcodes, 1bit_add_test) {
   interp.visit(add0);
   interp.visit(add1);
 
-  auto& frame = ctx.stack_top();
+  auto &frame = ctx.stack_top();
   auto expr0 = frame.lookup(add0, z3);
   auto expr1 = frame.lookup(add1, z3);
 
@@ -145,7 +145,7 @@ TEST(opcodes, basic_mul_test) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto mul1 = llvm::BinaryOperator::CreateMul(val1, val2, "mul1", &bb);
   auto mul2 = llvm::BinaryOperator::CreateMul(mul1, val3, "mul2", &bb);
 
@@ -169,7 +169,7 @@ TEST(opcodes, basic_sdiv_dev) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto div1 = llvm::BinaryOperator::CreateSDiv(val1, val2, "div1", &bb);
 
   interp.visitSDiv(*div1);
@@ -191,7 +191,7 @@ TEST(opcodes, basic_udiv_test) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto div1 = llvm::BinaryOperator::CreateUDiv(val1, val2, "div1", &bb);
 
   interp.visitUDiv(*div1);
@@ -214,7 +214,7 @@ TEST(opcodes, udiv_test_div_by_zero) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto div1 = llvm::BinaryOperator::CreateUDiv(val1, val2, "div1", &bb);
 
   interp.visitUDiv(*div1);
@@ -244,7 +244,7 @@ TEST(opcodes, sdiv_test_div_by_zero) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto div1 = llvm::BinaryOperator::CreateSDiv(val1, val2, "div1", &bb);
 
   interp.visitSDiv(*div1);
@@ -263,7 +263,7 @@ TEST(opcodes, sdiv_test_div_by_zero) {
 }
 
 TEST(opcodes, sdiv_test_overflow) {
-   LLVMContext llvm;
+  LLVMContext llvm;
   z3::context z3 = default_context();
 
   auto func = empty_function(llvm);
@@ -273,7 +273,7 @@ TEST(opcodes, sdiv_test_overflow) {
   Context ctx{z3, func.get()};
   Interpreter interp{&ctx, nullptr, &z3};
 
-  auto& bb = func->getEntryBlock();
+  auto &bb = func->getEntryBlock();
   auto div1 = llvm::BinaryOperator::CreateSDiv(val1, val2, "div1", &bb);
 
   interp.visitSDiv(*div1);


### PR DESCRIPTION
A lot of the options we had in the `.clang-format` file both
a. Were re-specifying options that are already a part of the LLVM style, and
b. Didn't work well (or at all) on my machine.

This PR fixes both by removing the unnecessary options and by making sure the new version works on my machine. (By making sure we're not using any options newer than clang-format 3.8).

I've also configured the namespace indentation to indent nested namespaces as my experience is that it's rather confusing to have no indentation at all.

I think this closes #2.

Note: we should probably wait to merge this until #33 lands as there's going to be merge conflicts everywhere.