### PR TITLE
Get code execution (mostly) working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 find_package(LLVM 10.0 REQUIRED)
 find_package(GTest REQUIRED)
-find_package(Z3 REQUIRED)
+find_package(Z3 4.8.7 REQUIRED)
 find_package(Boost REQUIRED)
+find_package(fmt REQUIRED)
 
 enable_testing()
 
@@ -78,14 +79,18 @@ target_include_directories(decaf PUBLIC "${LLVM_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${Z3_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${FMT_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${Boost_INCLUDE_DIRS}")
-target_link_libraries(decaf PUBLIC LLVMCore "${Z3_LIBRARIES}" fmt)
+target_link_libraries(decaf PUBLIC LLVMCore ${Z3_LIBRARIES} fmt::fmt)
 
 target_include_directories(decaf-tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tests")
 target_link_libraries(decaf-tests PRIVATE decaf)
 target_link_libraries(decaf-tests PRIVATE GTest::GTest)
 add_test(NAME decaf-tests COMMAND decaf-tests)
 
-set_target_properties(decaf-bin PROPERTIES OUTPUT_NAME decaf)
+if (NOT WIN32)
+  # Having the executable have the same name as the library results in
+  # the output pdb files being overwritten.
+  set_target_properties(decaf-bin PROPERTIES OUTPUT_NAME decaf)
+endif ()
 target_link_libraries(decaf-bin PRIVATE decaf)
 target_link_libraries(decaf-bin PRIVATE LLVMIRReader)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(decaf PUBLIC "${LLVM_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${Z3_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${FMT_INCLUDE_DIRS}")
 target_include_directories(decaf PUBLIC "${Boost_INCLUDE_DIRS}")
-target_link_libraries(decaf PUBLIC LLVMCore "${Z3_LIBRARIES}")
+target_link_libraries(decaf PUBLIC LLVMCore "${Z3_LIBRARIES}" fmt)
 
 target_include_directories(decaf-tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tests")
 target_link_libraries(decaf-tests PRIVATE decaf)

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -173,7 +173,25 @@ public:
 private:
   ExecutionResult visitExternFunc(llvm::CallInst &inst);
 
+  /**
+   * Implements decaf_assume. Docs follow:
+   *
+   * Assume that a condition is true.
+   *
+   * This will silently remove any executions in which the condition
+   * could evaluate to false.
+   */
   ExecutionResult visitAssume(llvm::CallInst &inst);
+
+  /**
+   * Implements decaf_assert. Docs follow:
+   *
+   * Assert that the condition is true.
+   *
+   * In cases where the symbolic executor determines that the
+   * condition could be false, it will produce a test case with
+   * concrete inputs which reproduce the failure.
+   */
   ExecutionResult visitAssert(llvm::CallInst &inst);
 };
 

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -22,6 +22,14 @@ public:
   StackFrame(llvm::Function *function);
 
   /**
+   * Change the instruction pointer to point at the start of the provided
+   * block and update the previous block accordingly.
+   *
+   * Use this when implementing a jump instruction.
+   */
+  void jump_to(llvm::BasicBlock *block);
+
+  /**
    * Insert a new value into the current stack frame. If that value
    * is already in the current stack frame then it overwrites it.
    */
@@ -139,9 +147,7 @@ public:
   // Marks an unimplemented instruction.
   //
   // TODO: Better error message?
-  ExecutionResult visitInstruction(llvm::Instruction &) {
-    DECAF_UNIMPLEMENTED();
-  }
+  ExecutionResult visitInstruction(llvm::Instruction &);
 
   // Replace this with implementation in cpp file as we go
   ExecutionResult visitAdd(llvm::BinaryOperator &op);

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -161,9 +161,13 @@ public:
   ExecutionResult visitPHINode(llvm::PHINode &node);
   ExecutionResult visitBranchInst(llvm::BranchInst &inst);
   ExecutionResult visitReturnInst(llvm::ReturnInst &inst);
-  ExecutionResult visitCallInst(llvm::CallInst &inst) {
-    DECAF_UNIMPLEMENTED();
-  }
+  ExecutionResult visitCallInst(llvm::CallInst &inst);
+
+private:
+  ExecutionResult visitExternFunc(llvm::CallInst &inst);
+
+  ExecutionResult visitAssume(llvm::CallInst &inst);
+  ExecutionResult visitAssert(llvm::CallInst &inst);
 };
 
 /**

--- a/include/decaf.h
+++ b/include/decaf.h
@@ -162,6 +162,7 @@ public:
   ExecutionResult visitBranchInst(llvm::BranchInst &inst);
   ExecutionResult visitReturnInst(llvm::ReturnInst &inst);
   ExecutionResult visitCallInst(llvm::CallInst &inst);
+  ExecutionResult visitSelectInst(llvm::SelectInst &inst);
 
 private:
   ExecutionResult visitExternFunc(llvm::CallInst &inst);

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -2,15 +2,14 @@
 #include "macros.h"
 
 #include <boost/core/demangle.hpp>
-#include <boost/stacktrace.hpp>
 
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 
 namespace decaf::detail {
 [[noreturn]] void assert_fail(const char *condition, const char *function, unsigned int line,
                               const char *file, message message) {
-  auto stacktrace = boost::stacktrace::stacktrace();
   auto demangled = boost::core::demangle(function);
 
   std::cerr << "Assertion failed: " << condition << "\n"
@@ -21,14 +20,11 @@ namespace decaf::detail {
     std::cerr << "  message: " << message.msg << "\n";
   }
 
-  std::cerr << "\n" << stacktrace << "\n";
-
-  std::exit(255);
+  std::abort();
 }
 
 [[noreturn]] void abort(const char *function, unsigned int line, const char *file,
                         message message) {
-  auto stacktrace = boost::stacktrace::stacktrace();
   auto demangled = boost::core::demangle(function);
 
   if (message.has_value) {
@@ -38,10 +34,8 @@ namespace decaf::detail {
     std::cerr << "Aborted at " << file << ":" << line << "\n";
   }
 
-  std::cerr << "  function: " << demangled << "\n"
-            << "  Stack Trace:\n"
-            << stacktrace << "\n";
+  std::cerr << "  function: " << demangled << "\n";
 
-  std::exit(255);
+  std::abort();
 }
 } // namespace decaf::detail

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -385,6 +385,18 @@ ExecutionResult Interpreter::visitCallInst(llvm::CallInst &call) {
   return ExecutionResult::Continue;
 }
 
+ExecutionResult Interpreter::visitSelectInst(llvm::SelectInst &inst) {
+  auto &frame = ctx->stack_top();
+
+  auto cond = normalize_to_bool(frame.lookup(inst.getCondition(), *z3));
+  auto t_val = normalize_to_int(frame.lookup(inst.getTrueValue(), *z3));
+  auto f_val = normalize_to_int(frame.lookup(inst.getFalseValue(), *z3));
+
+  frame.insert(&inst, z3::ite(cond, t_val, f_val));
+
+  return ExecutionResult::Continue;
+}
+
 ExecutionResult Interpreter::visitExternFunc(llvm::CallInst &call) {
   auto func = call.getCalledFunction();
   auto name = func->getName();


### PR DESCRIPTION
This commit has a bunch of mixed changes that came about as I tried to get the codebase to run actual LLVM IR. As such it contains a couple of unrelated changes:
- Implement the LLVM `select` instruction
- Implement the LLVM `call` instruction for local calls as well as *some* external functions
- Specify the required z3 version in CMakeLists.txt
- Fix `visitBranchInst` to actually jump to the correct branch (previously this had the branches reversed)
- Fix a couple of other small bugs
- Fix the order of declarations within `src/decaf.cpp`
- Remove the `boost::stacktrace` code in assertions in favor of just using LLVM's built in backtrace functionality by just calling `std::abort` at the end. (I wasn't able to get the previous stacktrace code working in most cases)

Most of this has been tested manually. I'm going to set up a testing runner and then I'll add the tests for this in a second commit. Once this commit lands we should be able run any programs that only contain the implemented opcodes.

I suspect that there's still a bunch of latent bugs in the code base (some of my more complicated test cases don't work correctly). I'm going to punt on this until I've got a better test setup since that'll make actually finding the bugs much easier.

Closes #27.
 