### PR TITLE
Add more tests and optimize Z3 solver configuration

### DIFF
--- a/include/decaf.h
+++ b/include/decaf.h
@@ -110,7 +110,7 @@ protected:
 
 public:
   // The current execution has encountered a failure.
-  virtual void add_failure(const Context &ctx, const z3::model &model) = 0;
+  virtual void add_failure(Context &ctx, const z3::model &model) = 0;
 };
 
 // Default FailureTracker if none is provided
@@ -118,7 +118,7 @@ class PrintingFailureTracker : public FailureTracker {
 public:
   PrintingFailureTracker() = default;
 
-  void add_failure(const Context &ctx, const z3::model &model) override;
+  void add_failure(Context &ctx, const z3::model &model) override;
 
   static FailureTracker *default_instance();
 };

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -61,7 +61,10 @@ z3::expr StackFrame::lookup(llvm::Value *value, z3::context &ctx) const {
 /************************************************
  * Context                                      *
  ************************************************/
-Context::Context(z3::context &z3, llvm::Function *function) : solver(z3) {
+
+Context::Context(z3::context &z3, llvm::Function *function) : 
+  solver(z3::tactic(z3, "default").mk_solver())
+{
   stack.emplace_back(function);
   StackFrame &frame = stack_top();
 
@@ -97,7 +100,7 @@ void Context::add(const z3::expr &assertion) {
 }
 
 Context Context::fork() const {
-  z3::solver new_solver{solver.ctx()};
+  z3::solver new_solver = z3::tactic(solver.ctx(), "default").mk_solver();
 
   for (const auto &assertion : solver.assertions()) {
     new_solver.add(assertion);

--- a/src/decaf.cpp
+++ b/src/decaf.cpp
@@ -479,7 +479,7 @@ ExecutionResult Interpreter::visitInstruction(llvm::Instruction &inst) {
 /************************************************
  * PrintingFailureTracker                       *
  ************************************************/
-void PrintingFailureTracker::add_failure(const Context &, const z3::model &model) {
+void PrintingFailureTracker::add_failure(Context &, const z3::model &model) {
   std::cout << "Found failed model! Inputs: \n" << model << std::endl;
 }
 

--- a/tests/run-fail/collatz.c
+++ b/tests/run-fail/collatz.c
@@ -1,0 +1,29 @@
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "decaf.h"
+
+uint32_t __attribute__((noinline)) modulo(uint32_t x, uint32_t y) {
+  return x % y;
+}
+
+uint32_t __attribute__((noinline)) collatz(uint32_t x) {
+  uint32_t cnt = 0;
+  while (x > 1) {
+    cnt += 1;
+
+    uint32_t k1 = x / 2;
+    uint32_t k2 = 3 * x + 1;
+
+    x = (modulo(x, 2) == 0) ? k1 : k2;
+    decaf_assume(cnt < 10);
+  }
+
+  return cnt;
+}
+
+void test(uint32_t n) {
+  decaf_assert(collatz(n) <= 2);
+}

--- a/tests/run-fail/sdiv-nonzero.c
+++ b/tests/run-fail/sdiv-nonzero.c
@@ -1,0 +1,10 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+// Test that signed division checks for overflow in the case
+// where x == INT_MIN and y == -1
+int32_t test(int32_t x, int32_t y) {
+  decaf_assume(y != 0);
+  return x / y;
+}

--- a/tests/run-fail/sdiv-udiv-inequal.c
+++ b/tests/run-fail/sdiv-udiv-inequal.c
@@ -1,0 +1,26 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+uint32_t sdiv(uint32_t x, uint32_t y) {
+  // Don't have or yet. Need to emulate it.
+  if (x == INT32_MIN)
+    decaf_assume(y != -1);
+  decaf_assume(y != 0);
+
+  return (int32_t)x / (int32_t)y;
+}
+
+uint32_t udiv(uint32_t x, uint32_t y) {
+  decaf_assume(y != 0);
+
+  return x / y;
+}
+
+// Test that udiv and sdiv are different for certain values.
+void test(uint32_t x, uint32_t y) {
+  uint32_t a = sdiv(x, y);
+  uint32_t b = udiv(x, y);
+
+  decaf_assert(a == b);
+}

--- a/tests/run-fail/sdiv-zero.c
+++ b/tests/run-fail/sdiv-zero.c
@@ -1,0 +1,12 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+// Test that signed division checks for divide-by-zero.
+int32_t test(int32_t x, int32_t y) {
+  // Don't have or yet. Need to emulate it.
+  if (x == INT32_MIN)
+    decaf_assume(y != -1);
+
+  return x / y;
+}

--- a/tests/run-pass/sdiv-negative.c
+++ b/tests/run-pass/sdiv-negative.c
@@ -1,0 +1,9 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+void test(int32_t x) {
+  decaf_assume(x == -50);
+  int32_t y = x / -5;
+  decaf_assert(y == 10);
+}

--- a/tests/run-pass/sdiv-udiv-equal-nonnegative.c
+++ b/tests/run-pass/sdiv-udiv-equal-nonnegative.c
@@ -1,0 +1,29 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+uint32_t sdiv(uint32_t x, uint32_t y) {
+  // Don't have or yet. Need to emulate it.
+  if (x == INT32_MIN)
+    decaf_assume(y != -1);
+  decaf_assume(y != 0);
+
+  return (int32_t)x / (int32_t)y;
+}
+
+uint32_t udiv(uint32_t x, uint32_t y) {
+  decaf_assume(y != 0);
+
+  return x / y;
+}
+
+// Test that udiv and sdiv are the same for positive values.
+void test(uint32_t x, uint32_t y) {
+  decaf_assume(x < 0x80000000);
+  decaf_assume(y < 0x80000000);
+
+  uint32_t a = sdiv(x, y);
+  uint32_t b = udiv(x, y);
+
+  decaf_assert(a == b);
+}

--- a/tests/run-pass/udiv-large.c
+++ b/tests/run-pass/udiv-large.c
@@ -1,0 +1,10 @@
+
+#include "decaf.h"
+#include <stdint.h>
+
+// Test that udiv works correctly for large values.
+void test(uint32_t x) {
+  decaf_assume(x == UINT32_MAX);
+  uint32_t y = x / 4294967246;
+  decaf_assert(y == 1);
+}

--- a/tests/test-common.hpp
+++ b/tests/test-common.hpp
@@ -25,8 +25,11 @@ class CountingFailureTracker : public FailureTracker {
 public:
   uint64_t count = 0;
 
-  void add_failure(const Context &, const z3::model &model) override {
+  void add_failure(Context &ctx, const z3::model &model) override {
     count += 1;
+
+    std::cout << "Found failure:\n" << model << std::endl;
+    std::cout << ctx.solver.to_smt2();
   }
 };
 


### PR DESCRIPTION
This PR adds a number of tests mostly focusing around division (both signed and unsigned). Along the way, I discovered that the `Context` argument to `FailureTracker::add_failure` is actually mostly useless if it's `const` since you can't do anything to inspect the solver so I've also changed that. Finally, I've explicitly specified the tactic used for the solver. See the commit message for why this helps improve performance.